### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/112/578/391/5/1125783915.geojson
+++ b/data/112/578/391/5/1125783915.geojson
@@ -258,6 +258,9 @@
     },
     "wof:country":"JE",
     "wof:created":1497290598,
+    "wof:geom_alt":[
+        "qs_pg"
+    ],
     "wof:geomhash":"91b8e5c35f572a8755b831c7691612b2",
     "wof:hierarchy":[
         {
@@ -269,7 +272,7 @@
         }
     ],
     "wof:id":1125783915,
-    "wof:lastmodified":1566724594,
+    "wof:lastmodified":1582321271,
     "wof:name":"Saint Helier",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/856/325/93/85632593.geojson
+++ b/data/856/325/93/85632593.geojson
@@ -666,6 +666,10 @@
     },
     "wof:country":"JE",
     "wof:country_alpha3":"JEY",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"083df51571959fb54c8d6984ad1bfbe9",
     "wof:hierarchy":[
         {
@@ -683,7 +687,7 @@
         "eng",
         "fre"
     ],
-    "wof:lastmodified":1566724590,
+    "wof:lastmodified":1582321271,
     "wof:name":"Jersey",
     "wof:parent_id":102191581,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.