### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/102/557/203/102557203.geojson
+++ b/data/102/557/203/102557203.geojson
@@ -13,6 +13,9 @@
     "mz:hierarchy_label":1,
     "mz:is_current":1,
     "mz:min_zoom":13.0,
+    "name:arz_x_preferred":[
+        "\u0645\u0637\u0627\u0631 \u062c\u064a\u0631\u0633\u0649"
+    ],
     "name:bel_x_preferred":[
         "\u0414\u0436\u044d\u0440\u0441\u0456"
     ],
@@ -50,6 +53,9 @@
     "name:jpn_x_preferred":[
         "\u30b8\u30e3\u30fc\u30b8\u30fc"
     ],
+    "name:jpn_x_variant":[
+        "\u30b8\u30e3\u30fc\u30b8\u30fc\u7a7a\u6e2f"
+    ],
     "name:lav_x_preferred":[
         "D\u017e\u0113rsijas lidosta"
     ],
@@ -57,6 +63,9 @@
         "Lapangan Terbang Jersey"
     ],
     "name:nld_x_preferred":[
+        "Jersey Airport"
+    ],
+    "name:nob_x_preferred":[
         "Jersey Airport"
     ],
     "name:pms_x_preferred":[
@@ -88,6 +97,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6fa4\u897f"
+    ],
+    "name:zho_x_variant":[
+        "\u6fa4\u897f\u6a5f\u5834"
     ],
     "oa:elevation_ft":"277",
     "oa:type":"medium_airport",
@@ -124,7 +136,7 @@
         }
     ],
     "wof:id":102557203,
-    "wof:lastmodified":1566724590,
+    "wof:lastmodified":1690937452,
     "wof:name":"Jersey Airport",
     "wof:parent_id":85681257,
     "wof:placetype":"campus",

--- a/data/112/578/391/5/1125783915.geojson
+++ b/data/112/578/391/5/1125783915.geojson
@@ -28,6 +28,9 @@
     "name:ara_x_preferred":[
         "\u0633\u0627\u064a\u0646\u062a \u0647\u064a\u0644\u064a\u0631"
     ],
+    "name:arg_x_preferred":[
+        "Saint Helier"
+    ],
     "name:ast_x_preferred":[
         "Saint-Helier"
     ],
@@ -39,6 +42,9 @@
     ],
     "name:bel_x_variant":[
         "\u0421\u0435\u043d\u0442-\u0425\u0435\u043b\u044c\u0435\u0440"
+    ],
+    "name:bos_x_preferred":[
+        "Saint Helier"
     ],
     "name:bre_x_preferred":[
         "Saint H\u00e9lyi"
@@ -65,6 +71,9 @@
         "Saint Helier"
     ],
     "name:deu_x_preferred":[
+        "Saint Helier"
+    ],
+    "name:diq_x_preferred":[
         "Saint Helier"
     ],
     "name:ell_x_preferred":[
@@ -96,6 +105,9 @@
         "Saint Helier"
     ],
     "name:gla_x_preferred":[
+        "Saint Helier"
+    ],
+    "name:gle_x_preferred":[
         "Saint Helier"
     ],
     "name:glg_x_preferred":[
@@ -151,6 +163,9 @@
     ],
     "name:mri_x_preferred":[
         "Saint Helier"
+    ],
+    "name:mzn_x_preferred":[
+        "\u0633\u0646\u062a \u0647\u0644\u06cc\u0647"
     ],
     "name:nan_x_preferred":[
         "Saint Helier"
@@ -224,6 +239,12 @@
     "name:war_x_preferred":[
         "Saint Helier"
     ],
+    "name:wuu_x_preferred":[
+        "\u5723\u8d6b\u5229\u5c14"
+    ],
+    "name:yue_x_preferred":[
+        "\u8056\u827e\u5229\u8036"
+    ],
     "name:zho_x_preferred":[
         "\u5723\u8d6b\u5229\u5c14"
     ],
@@ -274,7 +295,7 @@
         }
     ],
     "wof:id":1125783915,
-    "wof:lastmodified":1607390886,
+    "wof:lastmodified":1690937453,
     "wof:name":"Saint Helier",
     "wof:parent_id":-1,
     "wof:placetype":"locality",

--- a/data/112/580/542/3/1125805423.geojson
+++ b/data/112/580/542/3/1125805423.geojson
@@ -34,6 +34,9 @@
     "name:nld_x_preferred":[
         "Gorey"
     ],
+    "name:pol_x_preferred":[
+        "Gorey"
+    ],
     "name:zho_x_preferred":[
         "St. Martin"
     ],
@@ -87,7 +90,7 @@
         }
     ],
     "wof:id":1125805423,
-    "wof:lastmodified":1566724593,
+    "wof:lastmodified":1690937453,
     "wof:name":"Gorey",
     "wof:parent_id":85681257,
     "wof:placetype":"locality",

--- a/data/112/584/968/7/1125849687.geojson
+++ b/data/112/584/968/7/1125849687.geojson
@@ -52,6 +52,9 @@
     "name:ces_x_preferred":[
         "Le Rozel"
     ],
+    "name:che_x_preferred":[
+        "\u041b\u0435-\u0413\u04c0\u043e\u0437\u0435\u043b\u044c"
+    ],
     "name:cos_x_preferred":[
         "Le Rozel"
     ],
@@ -62,6 +65,9 @@
         "Le Rozel"
     ],
     "name:deu_x_preferred":[
+        "Le Rozel"
+    ],
+    "name:diq_x_preferred":[
         "Le Rozel"
     ],
     "name:eng_x_preferred":[
@@ -166,6 +172,9 @@
     "name:lit_x_preferred":[
         "Le Rozel"
     ],
+    "name:lld_x_preferred":[
+        "Le Rozel"
+    ],
     "name:ltz_x_preferred":[
         "Le Rozel"
     ],
@@ -250,6 +259,9 @@
     "name:swe_x_preferred":[
         "Le Rozel"
     ],
+    "name:tat_x_preferred":[
+        "\u041b\u0435-\u0420\u043e\u0437\u0435\u043b\u044c"
+    ],
     "name:tur_x_preferred":[
         "Le Rozel"
     ],
@@ -288,6 +300,9 @@
     ],
     "name:zho_x_preferred":[
         "\u52d2\u7f57\u6cfd"
+    ],
+    "name:zho_x_variant":[
+        "\u52d2\u7f57\u6cfd\u52d2"
     ],
     "name:zul_x_preferred":[
         "Le Rozel"
@@ -342,7 +357,7 @@
         }
     ],
     "wof:id":1125849687,
-    "wof:lastmodified":1566724594,
+    "wof:lastmodified":1690937454,
     "wof:name":"Rozel",
     "wof:parent_id":85681257,
     "wof:placetype":"locality",

--- a/data/856/325/93/85632593.geojson
+++ b/data/856/325/93/85632593.geojson
@@ -45,6 +45,9 @@
     "name:ang_x_preferred":[
         "C\u0113sar\u0113a"
     ],
+    "name:anp_x_preferred":[
+        "\u091c\u0930\u094d\u0938\u0940"
+    ],
     "name:ara_x_preferred":[
         "\u062c\u064a\u0631\u0632\u064a"
     ],
@@ -53,6 +56,9 @@
     ],
     "name:arg_x_preferred":[
         "J\u00e8rri"
+    ],
+    "name:arz_x_preferred":[
+        "\u062c\u064a\u0631\u0632\u0649"
     ],
     "name:ast_x_preferred":[
         "Jersey"
@@ -117,8 +123,14 @@
     "name:chr_x_preferred":[
         "\u13e8\u13b5\u13cf"
     ],
+    "name:ckb_x_preferred":[
+        "\u062c\u06ce\u0631\u0632\u06cc"
+    ],
     "name:cor_x_preferred":[
         "Jersi"
+    ],
+    "name:cos_x_preferred":[
+        "Jersey"
     ],
     "name:crh_x_preferred":[
         "Cersi"
@@ -130,6 +142,9 @@
         "Jersey"
     ],
     "name:deu_x_preferred":[
+        "Jersey"
+    ],
+    "name:diq_x_preferred":[
         "Jersey"
     ],
     "name:div_x_preferred":[
@@ -200,6 +215,9 @@
     ],
     "name:guj_x_preferred":[
         "\u0a9c\u0ab0\u0acd\u0ab8\u0ac0"
+    ],
+    "name:hak_x_preferred":[
+        "Jersey"
     ],
     "name:hau_x_preferred":[
         "Jersey"
@@ -273,6 +291,9 @@
     "name:kin_x_preferred":[
         "Jersey"
     ],
+    "name:kir_x_preferred":[
+        "\u0416\u0435\u0440\u0441\u0438"
+    ],
     "name:kor_x_preferred":[
         "\uc800\uc9c0 \uc12c"
     ],
@@ -309,6 +330,9 @@
     ],
     "name:mar_x_preferred":[
         "\u091c\u0930\u094d\u0938\u0940"
+    ],
+    "name:mdf_x_preferred":[
+        "\u0414\u0436\u044d\u0440\u0441\u0438"
     ],
     "name:mkd_x_preferred":[
         "\u040f\u0435\u0440\u0441\u0438"
@@ -396,8 +420,17 @@
         "\u0414\u0436\u0435\u0440\u0441\u0438 (\u043e\u0441\u0442\u0440\u043e\u0432)",
         "\u0414\u0436\u0435\u0440\u0441\u0438"
     ],
+    "name:sah_x_preferred":[
+        "\u0414\u0436\u0435\u0440\u0441\u0438"
+    ],
+    "name:scn_x_preferred":[
+        "Jersey"
+    ],
     "name:sco_x_preferred":[
         "Jersey"
+    ],
+    "name:shn_x_preferred":[
+        "\u1075\u103b\u1083\u1087\u101e\u102e\u1087"
     ],
     "name:sin_x_preferred":[
         "\u0da2\u0dbb\u0dca\u0dc3\u0dd2"
@@ -433,6 +466,9 @@
         "Jersey"
     ],
     "name:swe_x_preferred":[
+        "Jersey"
+    ],
+    "name:szl_x_preferred":[
         "Jersey"
     ],
     "name:tam_x_preferred":[
@@ -756,7 +792,7 @@
         "eng",
         "fre"
     ],
-    "wof:lastmodified":1617827433,
+    "wof:lastmodified":1690937453,
     "wof:name":"Jersey",
     "wof:parent_id":102191581,
     "wof:placetype":"country",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.