### PR TITLE
je concordances, placetype local, and more

### DIFF
--- a/data/856/325/93/85632593.geojson
+++ b/data/856/325/93/85632593.geojson
@@ -761,6 +761,7 @@
         "gn:id":3042142,
         "gp:id":23424857,
         "hasc:id":"JE",
+        "iso:code":"JE",
         "m49:code":"832",
         "marc:id":"uik",
         "mzb:id":"jersey",
@@ -770,6 +771,7 @@
         "uncrt:id":"GBJ",
         "wd:id":"Q785"
     },
+    "wof:concordances_official":"iso:code",
     "wof:coterminous":[
         85681257
     ],
@@ -796,7 +798,7 @@
         "eng",
         "fre"
     ],
-    "wof:lastmodified":1694639517,
+    "wof:lastmodified":1695881172,
     "wof:name":"Jersey",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/812/57/85681257.geojson
+++ b/data/856/812/57/85681257.geojson
@@ -361,8 +361,10 @@
     "wof:breaches":[],
     "wof:concordances":{
         "gp:id":23424857,
+        "iso:code_pseudo":"JE",
         "qs_pg:id":1314370
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:coterminous":[
         85632593
     ],
@@ -382,7 +384,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1694493126,
+    "wof:lastmodified":1695884282,
     "wof:name":"Jersey",
     "wof:parent_id":85632593,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.